### PR TITLE
Alternate iterm2 colorschemes

### DIFF
--- a/iterm2/gruvbox-dark.itermcolors
+++ b/iterm2/gruvbox-dark.itermcolors
@@ -2,167 +2,343 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.156862745098039</real>
-		<key>Green Component</key>
-		<real>0.156862745098039</real>
-		<key>Red Component</key>
-		<real>0.156862745098039</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Green Component</key>
-		<real>0.858823529411765</real>
-		<key>Blue Component</key>
-		<real>0.698039215686274</real>
-		<key>Red Component</key>
-		<real>0.92156862745098</real>
-	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.156862745098039</real>
+		<real>0.11759774386882782</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.156862745098039</real>
+		<real>0.11759573966264725</real>
 		<key>Red Component</key>
-		<real>0.156862745098039</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.392156862745098</real>
-		<key>Green Component</key>
-		<real>0.435294117647059</real>
-		<key>Red Component</key>
-		<real>0.486274509803922</real>
+		<real>0.11759927868843079</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
-		<key>Red Component</key>
-		<real>0.8</real>
-		<key>Green Component</key>
-		<real>0.141176470588235</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.113725490196078</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.203921568627451</real>
+		<real>0.090684391558170319</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.286274509803922</real>
+		<real>0.05879192054271698</real>
 		<key>Red Component</key>
-		<real>0.984313725490196</real>
-	</dict>
-	<key>Ansi 2 Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.101960784313725</real>
-		<key>Green Component</key>
-		<real>0.592156862745098</real>
-		<key>Red Component</key>
-		<real>0.596078431372549</real>
+		<real>0.74529051780700684</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
-		<key>Red Component</key>
-		<real>0.72156862745098</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.149019607843137</real>
+		<real>0.11661489307880402</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.733333333333333</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
+		<real>0.69061970710754395</real>
 		<key>Red Component</key>
-		<real>0.843137254901961</real>
-		<key>Green Component</key>
-		<real>0.6</real>
-		<key>Blue Component</key>
-		<real>0.129411764705882</real>
+		<real>0.66574931144714355</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.741176470588235</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.184313725490196</real>
-		<key>Red Component</key>
-		<real>0.980392156862745</real>
-	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
+		<real>0.1444794088602066</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.52156862745098</real>
-		<key>Blue Component</key>
-		<real>0.533333333333333</real>
+		<real>0.6926688551902771</real>
 		<key>Red Component</key>
-		<real>0.270588235294118</real>
+		<real>0.96949708461761475</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.596078431372549</real>
+		<real>0.52537077665328979</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.647058823529412</real>
+		<real>0.58534377813339233</real>
 		<key>Red Component</key>
-		<real>0.513725490196078</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
-		<key>Green Component</key>
-		<real>0.384313725490196</real>
-		<key>Blue Component</key>
-		<real>0.525490196078431</real>
-		<key>Red Component</key>
-		<real>0.694117647058824</real>
+		<real>0.44289660453796387</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.525490196078431</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.607843137254902</real>
-		<key>Red Component</key>
-		<real>0.827450980392157</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.415686274509804</real>
+		<real>0.53848373889923096</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.615686274509804</real>
+		<real>0.43883562088012695</real>
 		<key>Red Component</key>
-		<real>0.407843137254902</real>
+		<real>0.78096956014633179</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
-		<key>Red Component</key>
-		<real>0.556862745098039</real>
-		<key>Green Component</key>
-		<real>0.752941176470588</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.486274509803922</real>
-	</dict>
-	<key>Ansi 7 Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.576470588235294</real>
+		<real>0.41142863035202026</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.682352941176471</real>
+		<real>0.71257460117340088</real>
 		<key>Red Component</key>
-		<real>0.741176470588235</real>
+		<real>0.49072420597076416</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
-		<key>Red Component</key>
-		<real>0.92156862745098</real>
-		<key>Green Component</key>
-		<real>0.858823529411765</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.698039215686274</real>
+		<real>0.73338055610656738</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.93639552593231201</real>
+		<key>Red Component</key>
+		<real>0.97939503192901611</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.082894742488861084</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.53061914443969727</real>
+		<key>Red Component</key>
+		<real>0.52591603994369507</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.10328958928585052</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.53254079818725586</real>
+		<key>Red Component</key>
+		<real>0.80126690864562988</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.4586675763130188</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.45008346438407898</real>
+		<key>Red Component</key>
+		<real>0.21694663166999817</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.45103743672370911</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.29604318737983704</real>
+		<key>Red Component</key>
+		<real>0.62685638666152954</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.34128850698471069</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.55607825517654419</real>
+		<key>Red Component</key>
+		<real>0.34054014086723328</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.63873869180679321</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.82989895343780518</real>
+		<key>Red Component</key>
+		<real>0.90061241388320923</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.37962067127227783</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.43934443593025208</real>
+		<key>Red Component</key>
+		<real>0.49889594316482544</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.15763583779335022</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.18880486488342285</real>
+		<key>Red Component</key>
+		<real>0.96744710206985474</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.11759774386882782</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.11759573966264725</real>
+		<key>Red Component</key>
+		<real>0.11759927868843079</real>
+	</dict>
+	<key>Badge Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.5</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.44320183992385864</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.5310559868812561</real>
+		<key>Red Component</key>
+		<real>0.5926094651222229</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.73299998044967651</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.73299998044967651</real>
+		<key>Red Component</key>
+		<real>0.73299998044967651</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.25</real>
+		<key>Blue Component</key>
+		<real>1</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.9100000262260437</real>
+		<key>Red Component</key>
+		<real>0.64999997615814209</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>1</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>1</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.63873869180679321</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.82989895343780518</real>
+		<key>Red Component</key>
+		<real>0.90061241388320923</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.67799997329711914</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.27000001072883606</real>
+		<key>Red Component</key>
+		<real>0.023000000044703484</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.44320183992385864</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.5310559868812561</real>
+		<key>Red Component</key>
+		<real>0.5926094651222229</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.31861674785614014</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.360250324010849</real>
+		<key>Red Component</key>
+		<real>0.40959125757217407</real>
 	</dict>
 </dict>
 </plist>

--- a/iterm2/gruvbox-light.itermcolors
+++ b/iterm2/gruvbox-light.itermcolors
@@ -2,167 +2,343 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.756862745098039</real>
-		<key>Red Component</key>
-		<real>0.992156862745098</real>
-		<key>Green Component</key>
-		<real>0.956862745098039</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Green Component</key>
-		<real>0.219607843137255</real>
-		<key>Red Component</key>
-		<real>0.235294117647059</real>
-		<key>Blue Component</key>
-		<real>0.211764705882353</real>
-	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.956862745098039</real>
-		<key>Red Component</key>
-		<real>0.992156862745098</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.756862745098039</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
+		<real>0.15993706881999969</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.6</real>
-		<key>Blue Component</key>
-		<real>0.517647058823529</real>
+		<real>0.16613791882991791</real>
 		<key>Red Component</key>
-		<real>0.658823529411765</real>
+		<real>0.17867125570774078</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.141176470588235</real>
-		<key>Red Component</key>
-		<real>0.8</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.113725490196078</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
+		<real>0.090684391558170319</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0</real>
+		<real>0.05879192054271698</real>
 		<key>Red Component</key>
-		<real>0.615686274509804</real>
-		<key>Blue Component</key>
-		<real>0.0235294117647059</real>
-	</dict>
-	<key>Ansi 2 Color</key>
-	<dict>
-		<key>Red Component</key>
-		<real>0.596078431372549</real>
-		<key>Blue Component</key>
-		<real>0.101960784313725</real>
-		<key>Green Component</key>
-		<real>0.592156862745098</real>
+		<real>0.74529051780700684</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.0549019607843137</real>
-		<key>Red Component</key>
-		<real>0.474509803921569</real>
+		<real>0.052511699497699738</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.454901960784314</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
+		<real>0.3858717679977417</real>
 		<key>Red Component</key>
-		<real>0.843137254901961</real>
-		<key>Blue Component</key>
-		<real>0.129411764705882</real>
-		<key>Green Component</key>
-		<real>0.6</real>
+		<real>0.3988109827041626</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.462745098039216</real>
-		<key>Red Component</key>
-		<real>0.709803921568627</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.0784313725490196</real>
-	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
+		<real>0.068556100130081177</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.52156862745098</real>
-		<key>Blue Component</key>
-		<real>0.533333333333333</real>
+		<real>0.38748690485954285</real>
 		<key>Red Component</key>
-		<real>0.270588235294118</real>
+		<real>0.64596939086914062</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.4</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.470588235294118</real>
-		<key>Red Component</key>
-		<real>0.0274509803921569</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
+		<real>0.39446473121643066</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.384313725490196</real>
-		<key>Blue Component</key>
-		<real>0.525490196078431</real>
+		<real>0.3268389105796814</real>
 		<key>Red Component</key>
-		<real>0.694117647058824</real>
+		<real>0.05438985675573349</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.247058823529412</real>
-		<key>Red Component</key>
-		<real>0.56078431372549</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.443137254901961</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
+		<real>0.36767596006393433</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.615686274509804</real>
-		<key>Blue Component</key>
-		<real>0.415686274509804</real>
+		<real>0.170136958360672</real>
 		<key>Red Component</key>
-		<real>0.407843137254902</real>
+		<real>0.48193711042404175</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.482352941176471</real>
-		<key>Red Component</key>
-		<real>0.258823529411765</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.345098039215686</real>
-	</dict>
-	<key>Ansi 7 Color</key>
-	<dict>
-		<key>Blue Component</key>
-		<real>0.329411764705882</real>
-		<key>Red Component</key>
-		<real>0.4</real>
+		<real>0.27463468909263611</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.36078431372549</real>
+		<real>0.41390609741210938</real>
+		<key>Red Component</key>
+		<real>0.2062048614025116</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
-		<key>Green Component</key>
-		<real>0.219607843137255</real>
-		<key>Red Component</key>
-		<real>0.235294117647059</real>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.211764705882353</real>
+		<real>0.73338055610656738</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.93639552593231201</real>
+		<key>Red Component</key>
+		<real>0.97939503192901611</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.082894742488861084</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.53061914443969727</real>
+		<key>Red Component</key>
+		<real>0.52591603994369507</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.10328958928585052</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.53254079818725586</real>
+		<key>Red Component</key>
+		<real>0.80126690864562988</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.4586675763130188</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.45008346438407898</real>
+		<key>Red Component</key>
+		<real>0.21694663166999817</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.45103743672370911</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.29604318737983704</real>
+		<key>Red Component</key>
+		<real>0.62685638666152954</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.34128850698471069</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.55607825517654419</real>
+		<key>Red Component</key>
+		<real>0.34054014086723328</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.63873869180679321</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.82989895343780518</real>
+		<key>Red Component</key>
+		<real>0.90061241388320923</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.37962067127227783</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.43934443593025208</real>
+		<key>Red Component</key>
+		<real>0.49889594316482544</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.034902941435575485</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>0.5389401912689209</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.73338055610656738</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.93639552593231201</real>
+		<key>Red Component</key>
+		<real>0.97939503192901611</real>
+	</dict>
+	<key>Badge Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.5</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.44320183992385864</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.5310559868812561</real>
+		<key>Red Component</key>
+		<real>0.5926094651222229</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.73299998044967651</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.73299998044967651</real>
+		<key>Red Component</key>
+		<real>0.73299998044967651</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.25</real>
+		<key>Blue Component</key>
+		<real>1</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.9100000262260437</real>
+		<key>Red Component</key>
+		<real>0.64999997615814209</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>1</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>1</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.15993706881999969</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.16613791882991791</real>
+		<key>Red Component</key>
+		<real>0.17867125570774078</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.67799997329711914</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.27000001072883606</real>
+		<key>Red Component</key>
+		<real>0.023000000044703484</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.44320183992385864</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.5310559868812561</real>
+		<key>Red Component</key>
+		<real>0.5926094651222229</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.31861674785614014</real>
+		<key>Color Space</key>
+		<string>Calibrated</string>
+		<key>Green Component</key>
+		<real>0.360250324010849</real>
+		<key>Red Component</key>
+		<real>0.40959125757217407</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
I noticed that using these color presets in iterm2 looks different. It was noticeable when running a terminal inside Neovim. And I thought, this should be the correct color sets.
I'm using iterm2 beta 2.9 by the way, haven't tested if this works in the stable iterm2.
Original color preset:
<img width="602" alt="screen shot 2015-11-30 at 9 43 27 am" src="https://cloud.githubusercontent.com/assets/7200153/11461908/f3324084-9746-11e5-82ee-468f818438fc.png">

Modified color preset:
<img width="602" alt="screen shot 2015-11-30 at 9 43 21 am" src="https://cloud.githubusercontent.com/assets/7200153/11461913/0c61b8c8-9747-11e5-8a00-266193676748.png">

Terminal inside neovim:
<img width="602" alt="screen shot 2015-11-30 at 9 43 30 am" src="https://cloud.githubusercontent.com/assets/7200153/11461912/0ad2270e-9747-11e5-8626-a442ee1cc689.png">
