### PR TITLE
Fix iTerm2 color space specification

### DIFF
--- a/iterm2/gruvbox-dark.itermcolors
+++ b/iterm2/gruvbox-dark.itermcolors
@@ -4,6 +4,8 @@
 <dict>
 	<key>Background Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.156862745098039</real>
 		<key>Green Component</key>
@@ -13,6 +15,8 @@
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.858823529411765</real>
 		<key>Blue Component</key>
@@ -22,6 +26,8 @@
 	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.156862745098039</real>
 		<key>Green Component</key>
@@ -31,6 +37,8 @@
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.392156862745098</real>
 		<key>Green Component</key>
@@ -40,6 +48,8 @@
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.8</real>
 		<key>Green Component</key>
@@ -49,6 +59,8 @@
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.203921568627451</real>
 		<key>Green Component</key>
@@ -58,6 +70,8 @@
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.101960784313725</real>
 		<key>Green Component</key>
@@ -67,6 +81,8 @@
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.72156862745098</real>
 		<key>Blue Component</key>
@@ -76,6 +92,8 @@
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.843137254901961</real>
 		<key>Green Component</key>
@@ -85,6 +103,8 @@
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.741176470588235</real>
 		<key>Blue Component</key>
@@ -94,6 +114,8 @@
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.52156862745098</real>
 		<key>Blue Component</key>
@@ -103,6 +125,8 @@
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.596078431372549</real>
 		<key>Green Component</key>
@@ -112,6 +136,8 @@
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.384313725490196</real>
 		<key>Blue Component</key>
@@ -121,6 +147,8 @@
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.525490196078431</real>
 		<key>Blue Component</key>
@@ -130,6 +158,8 @@
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.415686274509804</real>
 		<key>Green Component</key>
@@ -139,6 +169,8 @@
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.556862745098039</real>
 		<key>Green Component</key>
@@ -148,6 +180,8 @@
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.576470588235294</real>
 		<key>Green Component</key>
@@ -157,6 +191,8 @@
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.92156862745098</real>
 		<key>Green Component</key>

--- a/iterm2/gruvbox-light.itermcolors
+++ b/iterm2/gruvbox-light.itermcolors
@@ -4,6 +4,8 @@
 <dict>
 	<key>Background Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.756862745098039</real>
 		<key>Red Component</key>
@@ -13,6 +15,8 @@
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.219607843137255</real>
 		<key>Red Component</key>
@@ -22,6 +26,8 @@
 	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.956862745098039</real>
 		<key>Red Component</key>
@@ -31,6 +37,8 @@
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.6</real>
 		<key>Blue Component</key>
@@ -40,6 +48,8 @@
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.141176470588235</real>
 		<key>Red Component</key>
@@ -49,6 +59,8 @@
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0</real>
 		<key>Red Component</key>
@@ -58,6 +70,8 @@
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.596078431372549</real>
 		<key>Blue Component</key>
@@ -67,6 +81,8 @@
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.0549019607843137</real>
 		<key>Red Component</key>
@@ -76,6 +92,8 @@
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Red Component</key>
 		<real>0.843137254901961</real>
 		<key>Blue Component</key>
@@ -85,6 +103,8 @@
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.462745098039216</real>
 		<key>Red Component</key>
@@ -94,6 +114,8 @@
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.52156862745098</real>
 		<key>Blue Component</key>
@@ -103,6 +125,8 @@
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.4</real>
 		<key>Blue Component</key>
@@ -112,6 +136,8 @@
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.384313725490196</real>
 		<key>Blue Component</key>
@@ -121,6 +147,8 @@
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.247058823529412</real>
 		<key>Red Component</key>
@@ -130,6 +158,8 @@
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.615686274509804</real>
 		<key>Blue Component</key>
@@ -139,6 +169,8 @@
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.482352941176471</real>
 		<key>Red Component</key>
@@ -148,6 +180,8 @@
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.329411764705882</real>
 		<key>Red Component</key>
@@ -157,6 +191,8 @@
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
 		<real>0.219607843137255</real>
 		<key>Red Component</key>


### PR DESCRIPTION
The colors in the iTerm2 themes are written for the sRGB color space. However, by default iTerm2 interprets colors in the Generic RGB space. This means colors are showing up lighter than they should be. It is therefore necessary to specify the color space for each color as sRGB.

Further reading: https://github.com/gnachman/iTerm2/pull/149