### PR TITLE
Added gruvbox for CudaText & Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here's a list of ports to other text editors and applications. The original Vim 
 
 - [Caleb Land's port](https://github.com/caleb/gruvbox-syntax-atom)
 - [Ryan Taylor's port](https://github.com/ryanmt/atom-gruvbox-dark)
+- [Brian Reilly's port](https://github.com/Briles/gruvbox-atom)
 
 ### Sublime // TextMate
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Here's a list of ports to other text editors and applications. The original Vim 
 ### Sublime // TextMate
 
 - [Martin Radimec's port](https://github.com/peaceant/gruvbox)
-- [Brian Reilly's port](https://github.com/briles/gruvbox)
+- [Brian Reilly's port](https://github.com/Briles/gruvbox)
 
 ### Qt Creator
 
@@ -50,3 +50,7 @@ Here's a list of ports to other text editors and applications. The original Vim 
 ### Slack
 
 - [By unknown author](http://sweetthemesaremadeofthe.se/post/114732568417/gruvbox-inspired)
+
+### CudaText
+
+- [Brian Reilly's port](https://github.com/Briles/gruvbox-cudatext)


### PR DESCRIPTION
I was asked to port gruvbox to [CudaText](https://github.com/Alexey-T/CudaText), so I did. :+1: 

I also ported my gruvbox theme to [Atom](https://atom.io/themes/gruvbox-plus-syntax)