### PR TITLE
Sort and add another contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Here's a list of ports to other text editors and applications. The original Vim 
 - [Martin Radimec's port](https://github.com/peaceant/gruvbox)
 - [Brian Reilly's port](https://github.com/Briles/gruvbox)
 
+### Tilix terminal
+
+[Michael Thessel's port](https://github.com/MichaelThessel/tilix-gruvbox)
+
 ### Vimperator
 
 - [Raphael McSinyx's color scheme](https://github.com/McSinyx/debdotfiles/tree/master/vimperator/.vimperator/colors)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Palette
 
 Here's a list of ports to other text editors and applications. The original Vim theme can be found here: https://github.com/morhetz/gruvbox
 
-### Emacs
+### Alacritty
 
-- [Greduan's port](https://github.com/Greduan/emacs-theme-gruvbox)
+- [Daniel M. Capella's port](https://github.com/jwilm/alacritty/wiki/Color-schemes#gruvbox)
 
 ### Atom
 
@@ -28,46 +28,58 @@ Here's a list of ports to other text editors and applications. The original Vim 
 - [Brian Reilly's port](https://github.com/Briles/gruvbox-atom)
 - [Steve Lombardi's port](https://github.com/smlombardi/gruvbox-syntax)
 
-### Sublime // TextMate
+### Awesome WM
 
-- [Martin Radimec's port](https://github.com/peaceant/gruvbox)
-- [Brian Reilly's port](https://github.com/Briles/gruvbox)
+- [Raphael McSinyx's theme](https://github.com/McSinyx/debdotfiles/tree/master/awesome/.config/awesome/themes/gruvbox)
+
+### CudaText
+
+- [Brian Reilly's port](https://github.com/Briles/gruvbox-cudatext)
+
+### Emacs
+
+- [Greduan's port](https://github.com/Greduan/emacs-theme-gruvbox)
+
+### HyperTerm
+
+- [Gruvbox Dark Theme](https://github.com/mcchrish/hyperterm-gruvbox-dark)
 
 ### IDEA
 - [Caleb Land's port](https://github.com/caleb/gruvbox-idea)
 - [Visual Gruvbox (Medium Dark) by rphlmr](https://github.com/rphlmr/visual-gruvbox-medium-dark)
 
-### Qt Creator
+### Multimarkdown Composer
 
-- [Julian Konchunas's port](https://github.com/konchunas/gruvbox-qtcreator)
+- [jlxz's stylesheet](https://github.com/jlxz/mmdc_gruvbox_style)
 
 ### Pentadactyl
 
 - [Roman Inflianskas's color scheme](https://github.com/rominf/pentadactyl-gruvbox)
 
-### Vimperator
-
-- [Raphael McSinyx's color scheme](https://github.com/McSinyx/debdotfiles/tree/master/vimperator/.vimperator/colors)
-
-### Awesome WM
-
-- [Raphael McSinyx's theme](https://github.com/McSinyx/debdotfiles/tree/master/awesome/.config/awesome/themes/gruvbox)
-
-### Multimarkdown Composer
-
-- [jlxz's stylesheet](https://github.com/jlxz/mmdc_gruvbox_style)
-
 ### Pygments
 
 - [Dave Yarwood's port](https://github.com/daveyarwood/gruvbox-pygments)
+
+### Qt Creator
+
+- [Julian Konchunas's port](https://github.com/konchunas/gruvbox-qtcreator)
+
+### Rofi
+
+- [Color themes by Brian Hardisty](https://github.com/bardisty/gruvbox-rofi)
 
 ### Slack
 
 - [By unknown author](http://sweetthemesaremadeofthe.se/post/114732568417/gruvbox-inspired)
 
-### CudaText
+### Sublime // TextMate
 
-- [Brian Reilly's port](https://github.com/Briles/gruvbox-cudatext)
+- [Martin Radimec's port](https://github.com/peaceant/gruvbox)
+- [Brian Reilly's port](https://github.com/Briles/gruvbox)
+
+### Vimperator
+
+- [Raphael McSinyx's color scheme](https://github.com/McSinyx/debdotfiles/tree/master/vimperator/.vimperator/colors)
 
 ### Visual Studio
 
@@ -78,15 +90,3 @@ Here's a list of ports to other text editors and applications. The original Vim 
 ### Visual Studio Code
 
 - [Visual Gruvbox (Medium Dark) by rphlmr](https://marketplace.visualstudio.com/items?itemName=rphlmr.visual-gruvbox-medium-dark)
-
-### HyperTerm
-
-- [Gruvbox Dark Theme](https://github.com/mcchrish/hyperterm-gruvbox-dark)
-
-### Rofi
-
-- [Color themes by Brian Hardisty](https://github.com/bardisty/gruvbox-rofi)
-
-### Alacritty
-
-- [Daniel M. Capella's port](https://github.com/jwilm/alacritty/wiki/Color-schemes#gruvbox)


### PR DESCRIPTION
- sorted contrib versions in alphabetical order, it's easier not to miss what you're looking for this way
- although there's already a `terminix/` folder in the repo and I could have just renamed it to tilix (as this terminal was recently renamed due to some reasons) I found adding an alternative version of the color theme to README (with different contrast variants, unlike the version in this repo) to be a better solution.

PS: I think it may be worth either to remove `terminix/` folder from this repo, or to copy files from the contrib version that I've added to the `terminix/` folder and to rename it to `tilix/`.