### PR TITLE
Add link to mattermost version of theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Here's a list of ports to other text editors and applications. The original Vim 
 - [Caleb Land's port](https://github.com/caleb/gruvbox-idea)
 - [Visual Gruvbox (Medium Dark) by rphlmr](https://github.com/rphlmr/visual-gruvbox-medium-dark)
 
+### Mattermost
+
+- [magicmonty's gruvbox dark color
+    scheme](https://docs.mattermost.com/help/settings/theme-colors.html#gruvbox-dark-theme)
+
 ### Multimarkdown Composer
 
 - [jlxz's stylesheet](https://github.com/jlxz/mmdc_gruvbox_style)


### PR DESCRIPTION
Add a link for mattermost theme (gruvbox dark)

![themeGruvboxDark](https://user-images.githubusercontent.com/430541/58109806-3269cd80-7be6-11e9-8c5c-56e1d9bb0202.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/morhetz/gruvbox-contrib/84)
<!-- Reviewable:end -->
