### PR TITLE
Add gruvbox theme for kitty

### DIFF
--- a/kitty/gruvbox-dark
+++ b/kitty/gruvbox-dark
@@ -1,0 +1,30 @@
+# Gruvbox Dark
+
+# hard contrast
+# background    #1d2021
+
+# medium contrast
+background    #282828
+
+# soft contrast
+# background    #32302f
+
+foreground    #ebdbb2
+cursorColor   #ebdbb2
+
+color0        #282828
+color1        #cc241d
+color2        #98971a
+color3        #d79921
+color4        #458588
+color5        #b16286
+color6        #689d6a
+color8        #928374
+color7        #a89984
+color9        #fb4934
+color10       #b8bb26
+color11       #fabd2f
+color12       #83a598
+color13       #d3869b
+color14       #8ec07c
+color15       #ebdbb2

--- a/kitty/gruvbox-light
+++ b/kitty/gruvbox-light
@@ -1,0 +1,30 @@
+# Gruvbox Light
+
+# hard contrast
+# background #f9f5d7
+
+# Medium contrast
+background   #fbf1c7
+
+# soft contrast
+# background  #f2e5bc
+
+foreground   #3c3836
+cursorColor  #3c3836
+
+color0       #fdf4c1
+color1       #cc241d
+color2       #98971a
+color3       #d79921
+color4       #458588
+color5       #b16286
+color6       #689d6a
+color7       #7c6f64
+color8       #928374
+color9       #9d0006
+color10      #79740e
+color11      #b57614
+color12      #076678
+color13      #8f3f71
+color14      #427b58
+color15      #3c3836


### PR DESCRIPTION
Add gruvbox theme for the [Kitty Terminal Emulator](https://sw.kovidgoyal.net/kitty/)

![dark](https://user-images.githubusercontent.com/25652765/62507929-e1747900-b7d3-11e9-89c6-a4e2cb858639.png)

![light](https://user-images.githubusercontent.com/25652765/62507978-12ed4480-b7d4-11e9-9bba-77bcaedc6cb2.png)
