### PR TITLE
[st] Fix static declaration of externally used colour variables

### DIFF
--- a/st/gruvbox-dark.h
+++ b/st/gruvbox-dark.h
@@ -25,6 +25,6 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor
  */
-static unsigned int defaultfg = 15;
-static unsigned int defaultbg = 0;
-static unsigned int defaultcs = 15;
+unsigned int defaultfg = 15;
+unsigned int defaultbg = 0;
+unsigned int defaultcs = 15;

--- a/st/gruvbox-light.h
+++ b/st/gruvbox-light.h
@@ -25,6 +25,6 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor
  */
-static unsigned int defaultfg = 15;
-static unsigned int defaultbg = 0;
-static unsigned int defaultcs = 15;
+unsigned int defaultfg = 15;
+unsigned int defaultbg = 0;
+unsigned int defaultcs = 15;


### PR DESCRIPTION
The header files for no longer work, as the variables are erroneously declared static. This fixes that.