### PR TITLE
update bold color on iterm light theme

### DIFF
--- a/iterm2/gruvbox-light.itermcolors
+++ b/iterm2/gruvbox-light.itermcolors
@@ -241,13 +241,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.15993706881999969</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>1</real>
+		<real>0.16613791882991791</real>
 		<key>Red Component</key>
-		<real>1</real>
+		<real>0.17867125570774078</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>


### PR DESCRIPTION
The current bold color is `fffeff`, but it's not visible in white background, that's why I think `3c3735` is better

Previous
<img width="186" alt="Screenshot 2024-01-30 at 14 19 26" src="https://github.com/morhetz/gruvbox-contrib/assets/16197249/feb46c61-2de3-4065-b274-0b3cf447c1ea">

New
<img width="186" alt="Screenshot 2024-01-30 at 14 20 02" src="https://github.com/morhetz/gruvbox-contrib/assets/16197249/3c4429c4-1ceb-4eac-a402-2c0cd25b4ccc">
