### PR TITLE
[Xresources/XTerm] Explictly define cursorColor, fixed erroneous color and used color macros

### DIFF
--- a/xresources/gruvbox-dark.xresources
+++ b/xresources/gruvbox-dark.xresources
@@ -3,35 +3,53 @@
 ! Description: Retro groove colorscheme generalized
 ! Author: morhetz <morhetz@gmail.com>
 ! Source: https://github.com/morhetz/gruvbox-generalized
-! Last Modified: 6 Sep 2014
+! Last Modified: 27 February 2024
 ! -----------------------------------------------------------------------------
+! hard contrast: #define bg0h #1d2021
+! soft contrast: #define bg0s #32302f
+#define bg #282828
+#define fg1 #ebdbb2
+#define black #282828
+#define darkred #cc241d
+#define darkgreen #98971a
+#define darkyellow #d79921
+#define darkblue #458588
+#define darkpurple #b16286
+#define darkaqua #689d6a
+#define lightgray #a89984
+#define gray #928374
+#define red #fb4934
+#define green #b8bb26
+#define yellow #fabd2f
+#define blue #83a598
+#define purple #d3869b
+#define aqua #8ec07c
+#define white #ebdbb2
 
-! hard contrast: *background: #1d2021
-*background: #282828
-! soft contrast: *background: #32302f
-*foreground: #ebdbb2
+*background: bg
+*foreground: fg1
 ! Black + DarkGrey
-*color0:  #282828
-*color8:  #928374
+*color0:  black
+*color8:  gray
 ! DarkRed + Red
-*color1:  #cc241d
-*color9:  #fb4934
+*color1:  darkred
+*color9:  red
 ! DarkGreen + Green
-*color2:  #98971a
-*color10: #b8bb26
+*color2:  darkgreen
+*color10: green
 ! DarkYellow + Yellow
-*color3:  #d79921
-*color11: #fabd2f
+*color3:  darkyellow
+*color11: yellow
 ! DarkBlue + Blue
-*color4:  #458588
-*color12: #83a598
+*color4:  darkblue
+*color12: blue
 ! DarkMagenta + Magenta
-*color5:  #b16286
-*color13: #d3869b
+*color5:  darkpurple
+*color13: purple
 ! DarkCyan + Cyan
-*color6:  #689d6a
-*color14: #8ec07c
+*color6:  darkaqua
+*color14: aqua
 ! LightGrey + White
-*color7:  #a89984
-*color15: #ebdbb2
-*cursorColor: #ebdbb2
+*color7:  lightgray
+*color15: white
+*cursorColor: white

--- a/xresources/gruvbox-dark.xresources
+++ b/xresources/gruvbox-dark.xresources
@@ -34,3 +34,4 @@
 ! LightGrey + White
 *color7:  #a89984
 *color15: #ebdbb2
+*cursorColor: #ebdbb2

--- a/xresources/gruvbox-light.xresources
+++ b/xresources/gruvbox-light.xresources
@@ -34,3 +34,4 @@
 ! LightGrey + White
 *color7:  #7c6f64
 *color15: #3c3836
+*cursorColor: #3c3836

--- a/xresources/gruvbox-light.xresources
+++ b/xresources/gruvbox-light.xresources
@@ -3,13 +3,12 @@
 ! Description: Retro groove colorscheme generalized
 ! Author: morhetz <morhetz@gmail.com>
 ! Source: https://github.com/morhetz/gruvbox-generalized
-! Last Modified: 6 Sep 2014
+! Last Modified: 27 February 2024
 ! -----------------------------------------------------------------------------
 ! hard contrast: #define bg0h #f9f5d7
 ! soft contrast: #define bg0s #f2e5bc
 #define bg #fbf1c7
 #define fg #3c3836
-#define black #fdf4c1
 #define darkred #cc241d
 #define darkgreen #98971a
 #define darkyellow #d79921
@@ -30,7 +29,7 @@
 *background: bg
 *foreground: fg
 ! Black + DarkGrey
-*color0:  black
+*color0:  bg
 *color8:  gray
 ! DarkRed + Red
 *color1:  darkred

--- a/xresources/gruvbox-light.xresources
+++ b/xresources/gruvbox-light.xresources
@@ -5,33 +5,52 @@
 ! Source: https://github.com/morhetz/gruvbox-generalized
 ! Last Modified: 6 Sep 2014
 ! -----------------------------------------------------------------------------
+! hard contrast: #define bg0h #f9f5d7
+! soft contrast: #define bg0s #f2e5bc
+#define bg #fbf1c7
+#define fg #3c3836
+#define black #fdf4c1
+#define darkred #cc241d
+#define darkgreen #98971a
+#define darkyellow #d79921
+#define darkblue #458588
+#define darkpurple #b16286
+#define darkaqua #689d6a
+#define lightgray #7c6f64
+#define gray #928374
+#define red #9d0006
+#define green #79740e
+#define yellow #b57614
+#define blue #076678
+#define purple #8f3f71
+#define aqua #427b58
+#define white #3c3836
 
-! hard contrast: *background: #f9f5d7
-*background: #fbf1c7
-! soft contrast: *background: #f2e5bc
-*foreground: #3c3836
+
+*background: bg
+*foreground: fg
 ! Black + DarkGrey
-*color0:  #fdf4c1
-*color8:  #928374
+*color0:  black
+*color8:  gray
 ! DarkRed + Red
-*color1:  #cc241d
-*color9:  #9d0006
+*color1:  darkred
+*color9:  red
 ! DarkGreen + Green
-*color2:  #98971a
-*color10: #79740e
+*color2:  darkgreen
+*color10: green
 ! DarkYellow + Yellow
-*color3:  #d79921
-*color11: #b57614
+*color3:  darkyellow
+*color11: yellow
 ! DarkBlue + Blue
-*color4:  #458588
-*color12: #076678
+*color4:  darkblue
+*color12: blue
 ! DarkMagenta + Magenta
-*color5:  #b16286
-*color13: #8f3f71
+*color5:  darkpurple
+*color13: purple
 ! DarkCyan + Cyan
-*color6:  #689d6a
-*color14: #427b58
+*color6:  darkaqua
+*color14: aqua
 ! LightGrey + White
-*color7:  #7c6f64
-*color15: #3c3836
-*cursorColor: #3c3836
+*color7:  lightgray
+*color15: white
+*cursorColor: white


### PR DESCRIPTION
* This should fix #137 and the cursor should appear normal now even when merging (see screenshot).
* There was a typo in the color for `black` in gruvbox-light.xresources that I've fixed.
* I've also used macros (with `#define`) for the colors so it's more convenient to change them.